### PR TITLE
Replace the deprecated `:crypto.hmac/3` function

### DIFF
--- a/lib/addict/crypto.ex
+++ b/lib/addict/crypto.ex
@@ -7,7 +7,7 @@ Signs and verifies text
   Sign `plaintext` with a `key`
   """
   def sign(plaintext, key \\ Addict.Configs.secret_key) do
-    :crypto.hmac(:sha512, key, plaintext) |> Base.encode16
+    :crypto.mac(:hmac, :sha512, key, plaintext) |> Base.encode16
   end
 
   @doc """


### PR DESCRIPTION
with `:crypto.mac/4`. This will bump the minimum project requirement to
OTP 22.1 but will also make it compile under OTP 24.0.